### PR TITLE
Updates to classic-browser-fix and classic-theme-enable

### DIFF
--- a/mods/classic-browser-fix.wh.cpp
+++ b/mods/classic-browser-fix.wh.cpp
@@ -2,8 +2,8 @@
 // @id              classic-browser-fix
 // @name            Fix browsers for Windows Classic theme
 // @description     Forces the border from Aero Light theme to fix glitched border in Classic theme
-// @version         1.1
-// @author 			Anixx
+// @version         1.2
+// @author 			Anixx, levitation
 // @github 			https://github.com/Anixx
 // @include         msedge.exe
 // @include         chrome.exe
@@ -29,6 +29,6 @@ which fixes their glitches when using Windows Classic theme.
 
 BOOL Wh_ModInit() {
     Wh_Log(L"Init");
-    SetThemeAppProperties(0);
+    SetThemeAppProperties(STAP_ALLOW_CONTROLS);       //Without the STAP_ALLOW_CONTROLS flag the file save dialog fails to open.
     return TRUE;
 }

--- a/mods/classic-browser-fix.wh.cpp
+++ b/mods/classic-browser-fix.wh.cpp
@@ -6,6 +6,7 @@
 // @author 			Anixx
 // @github 			https://github.com/Anixx
 // @include         msedge.exe
+// @include         brave.exe
 // @include         chrome.exe
 // @include         chromium.exe
 // @include         Skype.exe

--- a/mods/classic-browser-fix.wh.cpp
+++ b/mods/classic-browser-fix.wh.cpp
@@ -3,7 +3,7 @@
 // @name            Fix browsers for Windows Classic theme
 // @description     Forces the border from Aero Light theme to fix glitched border in Classic theme
 // @version         1.2
-// @author 			Anixx, levitation
+// @author 			Anixx
 // @github 			https://github.com/Anixx
 // @include         msedge.exe
 // @include         chrome.exe
@@ -22,6 +22,7 @@ which fixes their glitches when using Windows Classic theme.
 
 ![Aero Lite](https://i.imgur.com/5enqSD8.png)
 
+Authors: Anixx, levitation
 */
 // ==/WindhawkModReadme==
 

--- a/mods/classic-theme-enable.wh.cpp
+++ b/mods/classic-theme-enable.wh.cpp
@@ -3,7 +3,7 @@
 // @name            Enable Classic Theme by handle method
 // @description     Disables theming by closing the handle
 // @version         1.2.0
-// @author          Anixx, levitation
+// @author          Anixx
 // @github 			https://github.com/Anixx
 // @include         winlogon.exe
 // @compilerOptions -lntdll -lwtsapi32
@@ -60,6 +60,7 @@ more classic, particularly, the *Enable SysListView32* mod and *Classic Taskbar 
 
 ![Windows Classic](https://i.imgur.com/gB7mwpp.png)
 
+Authors: Anixx, levitation
 */
 // ==/WindhawkModReadme==
 

--- a/mods/classic-theme-enable.wh.cpp
+++ b/mods/classic-theme-enable.wh.cpp
@@ -2,11 +2,11 @@
 // @id              classic-theme-enable
 // @name            Enable Classic Theme by handle method
 // @description     Disables theming by closing the handle
-// @version         1.0.3
-// @author          Anixx
+// @version         1.2.0
+// @author          Anixx, levitation
 // @github 			https://github.com/Anixx
 // @include         winlogon.exe
-// @compilerOptions -lntdll
+// @compilerOptions -lntdll -lwtsapi32
 // ==/WindhawkMod==
 
 // ==WindhawkModReadme==
@@ -69,6 +69,7 @@ more classic, particularly, the *Enable SysListView32* mod and *Classic Taskbar 
 #include <winternl.h>
 #include <aclapi.h>
 #include <securitybaseapi.h>
+#include <wtsapi32.h>
 
 // Define the prototype for the NtOpenSection function.
 extern "C" NTSTATUS NTAPI NtOpenSection(
@@ -77,17 +78,52 @@ extern "C" NTSTATUS NTAPI NtOpenSection(
     IN POBJECT_ATTRIBUTES ObjectAttributes
 );
 
-BOOL Wh_ModInit() {
 
-    Wh_Log(L"Init");
+HANDLE g_initThread = NULL;
+HANDLE g_initThreadStopSignal = NULL;
+
+
+BOOL TryInit(bool* abort) {
 
     // Retrieve the current session ID for the process.
     DWORD sessionId;
-    ProcessIdToSessionId(GetCurrentProcessId(), &sessionId);
+    if (!ProcessIdToSessionId(GetCurrentProcessId(), &sessionId))
+        return FALSE;     //retry
+
+
+    if (sessionId != WTSGetActiveConsoleSessionId()) {
+
+        //TODO: if the session is service session then quit the init thread AND do not retry - set the abort flag to true
+
+        WTS_CONNECTSTATE_CLASS* pConnectState = NULL;
+        DWORD bytesReturned;
+        bool sessionConnected = false;
+        if (
+            WTSQuerySessionInformationW(
+                WTS_CURRENT_SERVER_HANDLE,
+                WTS_CURRENT_SESSION,
+                WTSConnectState,
+                (LPWSTR*)&pConnectState,
+                &bytesReturned
+            )
+            && pConnectState
+            && bytesReturned == sizeof(WTS_CONNECTSTATE_CLASS)
+        ) {
+            sessionConnected = (*pConnectState == WTSActive);
+            //Wh_Log(L"Session connected: %ls", sessionConnected ? L"Yes" : L"No");
+        }
+
+        if (pConnectState)
+            WTSFreeMemory(pConnectState);
+
+        if (!sessionConnected)  //Modify RDP sessions only when they reach active state else RDP connections will fail
+            return FALSE;     //retry
+    }
 
 
     wchar_t sectionName[256];
-    swprintf_s(sectionName, _countof(sectionName), L"\\Sessions\\%lu\\Windows\\ThemeSection", sessionId);
+    if (swprintf_s(sectionName, _countof(sectionName), L"\\Sessions\\%lu\\Windows\\ThemeSection", sessionId) == -1)
+        return FALSE;     //retry
 
     // Define the name of the section object.
     UNICODE_STRING sectionObjectName;
@@ -103,6 +139,9 @@ BOOL Wh_ModInit() {
     Wh_Log("status: %u\n", status);
     Wh_Log("%s", sectionName);
 
+    if (!NT_SUCCESS(status))
+        return FALSE;     //retry
+
     // Define your SDDL string.
     LPCWSTR sddl = L"O:BAG:SYD:(A;;RC;;;IU)(A;;DCSWRPSDRCWDWO;;;SY)";
     PSECURITY_DESCRIPTOR psd = NULL;
@@ -110,7 +149,7 @@ BOOL Wh_ModInit() {
     // Convert the SDDL string to a security descriptor.
     if (!ConvertStringSecurityDescriptorToSecurityDescriptorW(sddl, SDDL_REVISION_1, &psd, NULL)) {
         CloseHandle(hSection);
-        return false;
+        return FALSE;     //retry
     }
 
     // Set the security descriptor for the object.
@@ -126,5 +165,98 @@ BOOL Wh_ModInit() {
     LocalFree(psd);
     CloseHandle(hSection);
 
-    return result;
+
+    return result;     //retry if SetKernelObjectSecurity failed
+}
+
+DWORD WINAPI InitThreadFunc(LPVOID param) {
+
+    Wh_Log(L"InitThreadFunc enter");
+
+    bool isRetry = false;
+retry:  //If Windhawk loads the mod too early then the classic theme initialisation will fail. Therefore we need to loop until the initialisation succeeds. Also if the mod is loaded into a RDP session too early then for some reason that would block the RDP session from successfully connecting. So we need to wait for session "active" state in case of RDP sessions. This is another reason for having a loop here.
+    if (isRetry) {
+        if (WaitForSingleObject(g_initThreadStopSignal, 16) != WAIT_TIMEOUT) {
+            Wh_Log(L"Shutting down InitThreadFunc before success");
+            return FALSE;
+        }
+    }
+    isRetry = true;
+
+    bool abort = false;
+    if (TryInit(&abort)) {
+        return TRUE;  //hooks done
+    }
+    else if (abort) {
+        return FALSE;   //a service session?
+    }
+    else {      //This winlogon.exe is associated with a non-console session that is not active yet. In this case we need to retry later, else the RDP connection will fail.
+        goto retry;
+    }
+}
+
+BOOL Wh_ModInit() {
+
+    Wh_Log(L"Init");
+
+
+    bool abort = false;
+    if (TryInit(&abort)) {
+        return TRUE;  //hooks done
+    }
+    else if (abort) {
+        return FALSE;   //a service session?
+    }
+    else {      //This winlogon.exe is associated with a non-console session that is not active yet. In this case we need to retry later, else the RDP connection will fail.
+        g_initThreadStopSignal = CreateEvent(
+            /*lpEventAttributes = */NULL,           // default security attributes
+            /*bManualReset = */TRUE,				// manual-reset event
+            /*bInitialState = */FALSE,              // initial state is nonsignaled
+            /*lpName = */NULL						// object name
+        );
+
+        if (!g_initThreadStopSignal) {
+            Wh_Log(L"CreateEvent failed");
+            return FALSE;
+        }
+
+        g_initThread = CreateThread(
+            /*lpThreadAttributes = */NULL,
+            /*dwStackSize = */0,
+            InitThreadFunc,
+            /*lpParameter = */NULL,
+            /*dwCreationFlags = */0, 	//The thread runs immediately after creation.
+            /*lpThreadId = */NULL
+        );
+
+        if (g_initThread) {
+            Wh_Log(L"InitThread started");
+            return TRUE;
+        }
+        else {
+            Wh_Log(L"CreateThread failed");
+            CloseHandle(g_initThreadStopSignal);
+            g_initThreadStopSignal = NULL;
+            return FALSE;
+        }
+    }
+}
+
+void Wh_ModUninit() {
+
+    Wh_Log(L"Uniniting...");
+
+    if (g_initThread) {
+        SetEvent(g_initThreadStopSignal);
+        WaitForSingleObject(g_initThread, INFINITE);
+        CloseHandle(g_initThread);
+        g_initThread = NULL;
+    }
+
+    if (g_initThreadStopSignal) {
+        CloseHandle(g_initThreadStopSignal);
+        g_initThreadStopSignal = NULL;
+    }
+
+    Wh_Log(L"Uninit complete");
 }


### PR DESCRIPTION
classic-browser-fix: Without the STAP_ALLOW_CONTROLS flag the file save dialog fails to open (at least in Edge browser). Also, adding Brave browser to the mod inclusions list.

This update fixes two issues in classic-theme-enable: Handling too early mod load and handling RDP sessions.
1) If Windhawk loads the mod too early during system startup then the classic theme initialisation would fail in Wh_ModInit(). Therefore we need to loop in a separate thread until the initialisation succeeds. Starting Windhawk early (during system startup, not during user login) will ensure that certain mods and hooks are applied as soon as possible, since some things cannot be adjusted or blocked in retrospect.
2) If the mod is loaded into a new starting RDP session too early (this is separate from system startup) then for some reason that would block the RDP session from successfully connecting. So we need to wait for the session "active" state in case of RDP sessions.