### PR TITLE
[syslistview32-enabler] restrict mods to file explorer windows

### DIFF
--- a/mods/syslistview32-enabler.wh.cpp
+++ b/mods/syslistview32-enabler.wh.cpp
@@ -10,9 +10,14 @@
 
 // ==WindhawkModReadme==
 /*
-Enables the SysListView32 control in File Explorer folder windows.
-This makes the view more compact and allows icon rearrangement.
-SysListView32 control has been used by default before Windows 7.
+Enables the SysListView32 control in explorer.exe process windows.  
+This makes the view more compact and allows icon rearrangement.  
+SysListView32 control has been used by default before Windows 7.  
+
+> ⚠️ **Warning**  
+> The mod alter by default every explorer.exe windows, including their child.  
+> However, a setting is available to limit the mod specifically to File Explorer windows.  
+> If you're using a custom start menu and have keyboard navigation issues, check this setting.
 
 Before:
 
@@ -25,7 +30,23 @@ After:
 */
 // ==/WindhawkModReadme==
 
+// ==WindhawkModSettings==
+/*
+- file_explorer_detection: false
+  $name: File Explorer windows restriction
+  $description: When enabled, this option restricts the mod's effect to File Explorer windows
+*/
+// ==/WindhawkModSettings==
+
+
+#include <minwindef.h>
+#include <windhawk_api.h>
+#include <windows.h>
 #include <windhawk_utils.h>
+#include <winnt.h>
+#include <cstddef>
+#include <unordered_map>
+#include <list>
 
 #ifdef _WIN64
 #define CALCON __cdecl
@@ -35,15 +56,33 @@ After:
 #define SCALCON L"__thiscall"
 #endif
 
-/* SysListView32 */
-typedef BOOL (* CALCON CDefView__UseItemsView_t)(void *);
-CDefView__UseItemsView_t CDefView__UseItemsView_orig;
-BOOL CALCON CDefView__UseItemsView_hook(void *pThis)
-{return FALSE;}
+/* Utils, constants declarations */
 
+bool IsWindowsExplorerWindow(void);
+class HWNDCache;
+const size_t kMaxCacheEntries = 128;
+struct {
+    bool fileExplorerDetection;
+} g_settings;
+
+/* SysListView32 */
+
+using CDefView__UseItemsView_t = BOOL (CALCON *)(void *);
+CDefView__UseItemsView_t CDefView__UseItemsView_orig = nullptr;
+BOOL CALCON CDefView__UseItemsView_hook(void* /*pThis*/) {
+    return g_settings.fileExplorerDetection && !IsWindowsExplorerWindow();
+}
+
+/* Hooking */
+
+void LoadSettings()
+{
+    g_settings.fileExplorerDetection = Wh_GetIntSetting(L"file_explorer_detection");
+}
 
 BOOL Wh_ModInit(void)
 {   
+    LoadSettings();
     HMODULE hShell32 = LoadLibraryW(L"shell32.dll");
     if (!hShell32)
     {
@@ -52,7 +91,6 @@ BOOL Wh_ModInit(void)
     }
 
     WindhawkUtils::SYMBOL_HOOK hooks[] = {
-
         {
             {
                 L"private: int "
@@ -71,4 +109,81 @@ BOOL Wh_ModInit(void)
         return FALSE;
     }
     return TRUE;
+}
+
+/* Utils */
+
+class HWNDCache 
+{
+public:
+    HWNDCache(size_t maxSize) : m_maxSize(maxSize) {}
+
+    bool TryGet(HWND hwnd, bool& result)
+    {
+        auto it = m_cacheMap.find(hwnd);
+        if (it == m_cacheMap.end()) return false;
+
+        m_cacheList.splice(m_cacheList.begin(), m_cacheList, it->second.second);
+        result = it->second.first;
+        return true;
+    }
+
+    void Insert(HWND hwnd, bool value)
+    {
+        auto it = m_cacheMap.find(hwnd);
+        if (it != m_cacheMap.end()) 
+        {
+            it->second.first = value;
+            m_cacheList.splice(m_cacheList.begin(), m_cacheList, it->second.second);
+            return;
+        }
+
+        m_cacheList.push_front(hwnd);
+        m_cacheMap[hwnd] = { value, m_cacheList.begin() };
+
+        if (m_cacheMap.size() > m_maxSize) 
+        {
+            HWND lru = m_cacheList.back();
+            m_cacheList.pop_back();
+            m_cacheMap.erase(lru);
+        }
+    }
+
+    size_t GetCacheSize()
+    {
+        return m_cacheList.size();
+    }
+
+private:
+    size_t m_maxSize;
+    std::list<HWND> m_cacheList;
+    std::unordered_map<HWND, std::pair<bool, std::list<HWND>::iterator>> m_cacheMap;
+};
+
+HWNDCache g_hwndCache(kMaxCacheEntries);
+
+bool IsWindowsExplorerWindow() {
+    Wh_Log(L"Cache size: %d", g_hwndCache.GetCacheSize());
+
+    HWND currentWindow = GetForegroundWindow();
+    if (!currentWindow) {
+        Wh_Log(L"No foreground window found");
+        return false;
+    }
+
+    bool cachedResult = false;
+    if (g_hwndCache.TryGet(currentWindow, cachedResult)) {
+        Wh_Log(L"Using cached result for HWND %p: %d", currentWindow, cachedResult);
+        return cachedResult;
+    }
+    
+    wchar_t className[MAX_CLASS_NAME] = {};
+    if (GetClassNameW(currentWindow, className, _countof(className)) == 0) {
+        Wh_Log(L"Failed to get class name for HWND %p", currentWindow);
+        return false;
+    }
+
+    bool isExplorer = wcsstr(className, L"CabinetWClass") != nullptr;
+    g_hwndCache.Insert(currentWindow, isExplorer);
+    return isExplorer;
 }


### PR DESCRIPTION
Hi

I made this PR to fix the mod applying to StartAllBack Start menu. 
When SysListView32 is used in the start menu search pane, keyboard navigation is broken and click handlers are somehow way slower.

I added an option to enable the detection and a not-so-minimalist caching system to optimize. 

I hope the modification is appropriate and belongs in your repository.

Thank you